### PR TITLE
Fixed Markdown link formatting.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -3,10 +3,10 @@
 Maps and slices go a long way in Go, but sometimes you need more. This is a collection of collections that may be useful.
 
 ## Queue
-A [queue](http://en.wikipedia.org/wiki/Queue_(data_structure%29) is a first-in first-out data structure.
+A [queue](http://en.wikipedia.org/wiki/Queue_(data_structure%29)) is a first-in first-out data structure.
 
 ## Set
-A [set](http://en.wikipedia.org/wiki/Set_(computer_science%29) is an unordered collection of unique values typically used for testing membership.
+A [set](http://en.wikipedia.org/wiki/Set_(computer_science%29)) is an unordered collection of unique values typically used for testing membership.
 
 ## Skip list
 A [skip list](http://en.wikipedia.org/wiki/Skip_list) is a data structure that stores nodes in a hierarchy of linked lists. It gives performance similar to binary search trees by using a random number of forward links to skip parts of the list.


### PR DESCRIPTION
The Wikipedia links had parentheses that clashed with the Markdown syntax of displaying links. Fixed by adding a closing  `)` bracket.